### PR TITLE
Add safeMath library

### DIFF
--- a/src/contracts/FrozenToken.sol
+++ b/src/contracts/FrozenToken.sol
@@ -36,7 +36,7 @@ contract FrozenToken is Owned {
 
 	// constructor sets the parameters of execution, _totalSupply is all units
 	function FrozenToken(uint _totalSupply, address _owner)
-		when_non_zero(_totalSupply)
+		when_past_zero(_totalSupply)
 	{
 		totalSupply = _totalSupply;
 		owner = _owner;
@@ -85,7 +85,7 @@ contract FrozenToken is Owned {
 	}
 
 	// a value should be > 0
-	modifier when_non_zero(uint _value) {
+	modifier when_past_zero(uint _value) {
 		require (_value > 0);
 		_;
 	}

--- a/src/contracts/FrozenToken.sol
+++ b/src/contracts/FrozenToken.sol
@@ -69,11 +69,6 @@ contract FrozenToken is Owned {
 		return true;
 	}
 
-	// no default function, simple contract only, entry-level users
-	function() public {
-		assert(false);
-	}
-
 	// the balance should be available
 	modifier when_owns(address _owner, uint _amount) {
 		require (accounts[_owner].balance >= _amount);

--- a/src/contracts/FrozenToken.sol
+++ b/src/contracts/FrozenToken.sol
@@ -32,8 +32,6 @@ contract FrozenToken is Owned {
 
 	// constructor sets the parameters of execution, _totalSupply is all units
 	function FrozenToken(uint _totalSupply, address _owner)
-    public
-		when_no_eth
 		when_non_zero(_totalSupply)
 	{
 		totalSupply = _totalSupply;
@@ -50,7 +48,6 @@ contract FrozenToken is Owned {
 	// make an account liquid: only liquid accounts can do this.
 	function makeLiquid(address _to)
 		public
-		when_no_eth
 		when_liquid(msg.sender)
 		returns(bool)
 	{
@@ -61,7 +58,6 @@ contract FrozenToken is Owned {
 	// transfer
 	function transfer(address _to, uint _value)
 		public
-		when_no_eth
 		when_owns(msg.sender, _value)
 		when_liquid(msg.sender)
 		returns(bool)
@@ -81,12 +77,6 @@ contract FrozenToken is Owned {
 	// the balance should be available
 	modifier when_owns(address _owner, uint _amount) {
 		require (accounts[_owner].balance >= _amount);
-		_;
-	}
-
-	// no ETH should be sent with the transaction
-	modifier when_no_eth {
-		require (msg.value == 0);
 		_;
 	}
 

--- a/src/contracts/FrozenToken.sol
+++ b/src/contracts/FrozenToken.sol
@@ -4,6 +4,8 @@
 
 pragma solidity ^0.4.17;
 
+import "./safeMath.sol";
+
 // From Owned.sol
 contract Owned {
 	modifier only_owner { require (msg.sender == owner); _; }
@@ -22,6 +24,8 @@ contract Owned {
 // Liquid accounts can make other accounts liquid and send their tokens
 // to other axccounts.
 contract FrozenToken is Owned {
+	using safeMath for uint;
+
 	event Transfer(address indexed from, address indexed to, uint value);
 
 	// this is as basic as can be, only the associated balance & liquidity
@@ -63,8 +67,8 @@ contract FrozenToken is Owned {
 		returns(bool)
 	{
 		Transfer(msg.sender, _to, _value);
-		accounts[msg.sender].balance -= _value;
-		accounts[_to].balance += _value;
+		accounts[msg.sender].balance = accounts[msg.sender].balance.sub(_value);
+		accounts[_to].balance = accounts[_to].balance.add(_value);
 
 		return true;
 	}

--- a/src/contracts/FrozenToken.sol
+++ b/src/contracts/FrozenToken.sol
@@ -22,9 +22,9 @@ contract Owned {
 // Liquid accounts can make other accounts liquid and send their tokens
 // to other axccounts.
 contract FrozenToken is Owned {
-	event Transfer(address indexed from, address indexed to, uint256 value);
+	event Transfer(address indexed from, address indexed to, uint value);
 
-	// this is as basic as can be, only the associated balance & allowances
+	// this is as basic as can be, only the associated balance & liquidity
 	struct Account {
 		uint balance;
 		bool liquid;
@@ -43,7 +43,7 @@ contract FrozenToken is Owned {
 	}
 
 	// balance of a specific address
-	function balanceOf(address _who) public constant returns (uint256) {
+	function balanceOf(address _who) public constant returns (uint) {
 		return accounts[_who].balance;
 	}
 
@@ -59,7 +59,7 @@ contract FrozenToken is Owned {
 	}
 
 	// transfer
-	function transfer(address _to, uint256 _value)
+	function transfer(address _to, uint _value)
 		public
 		when_no_eth
 		when_owns(msg.sender, _value)

--- a/src/contracts/FrozenToken.sol
+++ b/src/contracts/FrozenToken.sol
@@ -32,7 +32,7 @@ contract FrozenToken is Owned {
 
 	// constructor sets the parameters of execution, _totalSupply is all units
 	function FrozenToken(uint _totalSupply, address _owner)
-        public
+    public
 		when_no_eth
 		when_non_zero(_totalSupply)
 	{

--- a/src/contracts/MultiCertifier.sol
+++ b/src/contracts/MultiCertifier.sol
@@ -2,8 +2,7 @@
 //! By Parity Technologies, 2017.
 //! Released under the Apache Licence 2.
 
-pragma solidity ^0.4.16;
-
+pragma solidity ^0.4.17;
 // From Owned.sol
 contract Owned {
 	modifier only_owner { require (msg.sender == owner); _; }
@@ -17,12 +16,7 @@ contract Owned {
 
 // From Certifier.sol
 contract Certifier {
-	event Confirmed(address indexed who);
-	event Revoked(address indexed who);
 	function certified(address) constant returns (bool);
-	function get(address, string) constant returns (bytes32) {}
-	function getAddress(address, string) constant returns (address) {}
-	function getUint(address, string) constant returns (uint) {}
 }
 
 /**

--- a/src/contracts/MultiCertifier.sol
+++ b/src/contracts/MultiCertifier.sol
@@ -3,6 +3,7 @@
 //! Released under the Apache Licence 2.
 
 pragma solidity ^0.4.17;
+
 // From Owned.sol
 contract Owned {
 	modifier only_owner { require (msg.sender == owner); _; }

--- a/src/contracts/SecondPriceAuction.sol
+++ b/src/contracts/SecondPriceAuction.sol
@@ -61,9 +61,6 @@ contract SecondPriceAuction {
 		endTime = beginTime + 15 days;
 	}
 
-	// No default function, entry-level users
-	function() public { assert(false); }
-
 	// Public interaction:
 
 	/// Buyin function. Throws if the sale is not active. May refund some of the

--- a/src/contracts/SecondPriceAuction.sol
+++ b/src/contracts/SecondPriceAuction.sol
@@ -43,7 +43,7 @@ contract SecondPriceAuction {
 	// Constructor:
 
 	/// Simple constructor.
-	/// Token cap should take be in whole tokens, not smallest divisible units.
+	/// Token cap should be in whole tokens, not smallest divisible units.
 	function SecondPriceAuction(
     address _certifierContract,
     address _tokenContract,
@@ -91,7 +91,7 @@ contract SecondPriceAuction {
 		Buyin(msg.sender, accounted, msg.value, price);
 
 		// send to treasury
-		require (treasury.send(msg.value));
+		assert (treasury.send(msg.value));
 	}
 
 	/// Like buyin except no payment required and bonus automatically given.

--- a/src/contracts/SecondPriceAuction.sol
+++ b/src/contracts/SecondPriceAuction.sol
@@ -45,13 +45,13 @@ contract SecondPriceAuction {
 	/// Simple constructor.
 	/// Token cap should take be in whole tokens, not smallest divisible units.
 	function SecondPriceAuction(
-        address _certifierContract,
-        address _tokenContract,
-        address _treasury,
-        address _admin,
-        uint _beginTime,
-        uint _tokenCap
-    ) public {
+    address _certifierContract,
+    address _tokenContract,
+    address _treasury,
+    address _admin,
+    uint _beginTime,
+    uint _tokenCap
+  ) {
 		certifier = Certifier(_certifierContract);
 		tokenContract = Token(_tokenContract);
 		treasury = _treasury;

--- a/src/contracts/SecondPriceAuction.sol
+++ b/src/contracts/SecondPriceAuction.sol
@@ -7,7 +7,7 @@ import "./safeMath.sol";
 
 /// Stripped down ERC20 standard token interface.
 contract Token {
-	function transfer(address _to, uint256 _value) public returns (bool success);
+	function transfer(address _to, uint _value) public returns (bool success);
 }
 
 // From Certifier.sol

--- a/src/contracts/SecondPriceAuction.sol
+++ b/src/contracts/SecondPriceAuction.sol
@@ -10,12 +10,7 @@ contract Token {
 
 // From Certifier.sol
 contract Certifier {
-	event Confirmed(address indexed who);
-	event Revoked(address indexed who);
 	function certified(address) public constant returns (bool);
-	function get(address, string) public constant returns (bytes32);
-	function getAddress(address, string) public constant returns (address);
-	function getUint(address, string) public constant returns (uint);
 }
 
 /// Simple modified second price auction contract. Price starts high and monotonically decreases

--- a/src/contracts/SecondPriceAuction.sol
+++ b/src/contracts/SecondPriceAuction.sol
@@ -130,7 +130,7 @@ contract SecondPriceAuction {
 		uint tokens = total.div(endPrice);
 		totalFinalised = totalFinalised.add(total);
 		delete buyins[_who];
-		require (tokenContract.transfer(_who, tokens));
+		assert (tokenContract.transfer(_who, tokens));
 
 		Finalised(_who, tokens);
 

--- a/src/contracts/SecondPriceAuction.sol
+++ b/src/contracts/SecondPriceAuction.sol
@@ -3,6 +3,8 @@
 
 pragma solidity ^0.4.17;
 
+import "./safeMath.sol";
+
 /// Stripped down ERC20 standard token interface.
 contract Token {
 	function transfer(address _to, uint256 _value) public returns (bool success);
@@ -16,6 +18,8 @@ contract Certifier {
 /// Simple modified second price auction contract. Price starts high and monotonically decreases
 /// until all tokens are sold at the current price with currently received funds.
 contract SecondPriceAuction {
+	using safeMath for uint;
+
 	// Events:
 
 	/// Someone bought in at a particular max-price.

--- a/src/contracts/safeMath.sol
+++ b/src/contracts/safeMath.sol
@@ -3,7 +3,8 @@
 
 library safeMath {
   function mul(uint a, uint b) internal returns (uint) {
-    assert(a == 0 || (a * b) / a == b);
+    uint c = a * b;
+    assert(a == 0 || c / a == b);
     return c;
   }
 
@@ -18,7 +19,8 @@ library safeMath {
   }
 
   function add(uint a, uint b) internal returns (uint) {
-    assert((a + b) >= a);
+    uint c = a + b;
+    assert(c >= a);
     return c;
   }
 }

--- a/src/contracts/safeMath.sol
+++ b/src/contracts/safeMath.sol
@@ -1,0 +1,24 @@
+//! Copyright Parity Technologies, 2017.
+//! Released under the Apache Licence 2.
+
+library safeMath {
+  function mul(uint a, uint b) internal returns (uint) {
+    assert(a == 0 || (a * b) / a == b);
+    return c;
+  }
+
+  function div(uint a, uint b) internal returns (uint) {
+    uint c = a / b;
+    return c;
+  }
+
+  function sub(uint a, uint b) internal returns (uint) {
+    assert(b <= a);
+    return a - b;
+  }
+
+  function add(uint a, uint b) internal returns (uint) {
+    assert((a + b) >= a);
+    return c;
+  }
+}


### PR DESCRIPTION
### Added
- safeMath library

### Changed
- Renamed `when_non_zero` to `when_past_zero`
- Simplified Certifier interface
- `uint256` and `uint128` data types to `uint` and [attached](http://solidity.readthedocs.io/en/develop/contracts.html#using-for) safeMath library to `uint` type 
- Whenever eth send to treasury used `assert` instead of `require`
- When token send to participant used `assert` instead of `require`

### Removed
- `when_no_eth` modifier
- empty fallback functions
- public visibility type for constructors