### PR TITLE
Bonus extends beyond first hour until there's no interest

### DIFF
--- a/src/contracts/SecondPriceAuction.sol
+++ b/src/contracts/SecondPriceAuction.sol
@@ -278,7 +278,8 @@ contract SecondPriceAuction {
 		require (
 			ecrecover(STATEMENT_HASH, v, r, s) == who &&
 			certifier.certified(who) &&
-			isBasicAccount(who)
+			isBasicAccount(who) &&
+			msg.value >= DUST_LIMIT
 		);
 		_;
 	}
@@ -350,6 +351,9 @@ contract SecondPriceAuction {
 	uint constant public ERA_PERIOD = 5 minutes;
 
 	// Static constants:
+
+	/// Anything less than this is considered dust and cannot be used to buy in.
+	uint constant public DUST_LIMIT = 5 finney;
 
 	/// The hash of the statement which must be signed in order to buyin.
 	bytes32 constant public STATEMENT_HASH = keccak256(STATEMENT);


### PR DESCRIPTION
- Removes gas limit.
- Bonus continues at 15% beyond first hour until there are 5 consecutive blocks with no new buyers.

Closes #30 