### PR TITLE
Gradually reduce bonus as interest fades

### DIFF
--- a/src/contracts/SecondPriceAuction.sol
+++ b/src/contracts/SecondPriceAuction.sol
@@ -278,7 +278,8 @@ contract SecondPriceAuction {
 		require (
 			ecrecover(STATEMENT_HASH, v, r, s) == who &&
 			certifier.certified(who) &&
-			isBasicAccount(who)
+			isBasicAccount(who) &&
+			msg.value >= DUST_LIMIT
 		);
 		_;
 	}
@@ -350,6 +351,9 @@ contract SecondPriceAuction {
 	uint constant public ERA_PERIOD = 5 minutes;
 
 	// Static constants:
+
+	/// Anything less than this is considered dust and cannot be used to buy in.
+	uint constant public DUST_LIMIT = 5 finney;
 
 	/// The hash of the statement which must be signed in order to buyin.
 	bytes32 constant public STATEMENT_HASH = keccak256(STATEMENT);

--- a/src/contracts/SecondPriceAuction.sol
+++ b/src/contracts/SecondPriceAuction.sol
@@ -82,15 +82,17 @@ contract SecondPriceAuction {
 		flushEra();
 
 		// Flush bonus period:
-		if (currentBonus > 0									// Bonus currently active
-			&& now >= beginTime + BONUS_DURATION				// But outside the automatic bonus period
-			&& lastNewInterest + BONUS_LATCH <= block.number	// And had no new interest for some blocks
-		) {
-			currentBonus--;
-		} else if (buyins[msg.sender].received == 0) {
-			lastNewInterest = uint32(block.number);
+		if (currentBonus > 0) {
+			// Bonus is currently active...
+			if (now >= beginTime + BONUS_DURATION					// ...but outside the automatic bonus period
+				&& lastNewInterest + BONUS_LATCH <= block.number	// ...and had no new interest for some blocks
+			) {
+				currentBonus--;
+			}
+			if (buyins[msg.sender].received == 0) {	// We have new interest
+				lastNewInterest = uint32(block.number);
+			}
 		}
-
 
 		uint accounted;
 		bool refund;


### PR DESCRIPTION
- Removes gas limit.
- Bonus drops 1 pp (until 0) whenever there are 3 consecutive blocks with no new purchasers.

Closes #30 